### PR TITLE
Removing attribute deletion

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"
+
+ThisBuild / libraryDependencySchemes ++= Seq("org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always)

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -271,30 +271,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-    delete:
-      tags:
-        - attributes
-      summary: Deletes an attribute within a tenant
-      operationId: deleteTenantAttribute
-      responses:
-        '200':
-          description: the tenant corresponding to the external id
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Tenant'
-        '400':
-          description: Invalid input
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-        '404':
-          description: Tenant or Attribute not found
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
   /tenants/origin/{origin}/code/{code}:
     parameters:
       - $ref: '#/components/parameters/CorrelationIdHeader'

--- a/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/Adapters.scala
+++ b/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/Adapters.scala
@@ -156,10 +156,7 @@ object Adapters {
       p.copy(attributes = attr :: p.attributes, updatedAt = time.some)
 
     def updateAttribute(attr: PersistentTenantAttribute, time: OffsetDateTime): PersistentTenant =
-      deleteAttribute(attr.id, time).addAttribute(attr, time)
-
-    def deleteAttribute(id: UUID, time: OffsetDateTime): PersistentTenant =
-      p.copy(attributes = p.attributes.filterNot(_.id == id), updatedAt = time.some)
+      p.copy(attributes = attr :: p.attributes.filterNot(_.id == attr.id), updatedAt = time.some)
   }
 
   implicit class PersistentTenantObjectWrapper(private val p: PersistentTenant.type) extends AnyVal {

--- a/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/TenantPersistentBehavior.scala
+++ b/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/TenantPersistentBehavior.scala
@@ -65,13 +65,6 @@ object TenantPersistentBehavior {
 
         result.fold(fail(_)(replyTo), t => persistAndReply(t, TenantUpdated)(replyTo))
 
-      case DeleteAttribute(tenantId, attributeId, dateTime, replyTo) =>
-        val result: Either[Throwable, PersistentTenant] = for {
-          maybeTenant <- state.tenants.get(tenantId).toRight(NotFoundTenant(tenantId))
-          _           <- maybeTenant.getAttribute(attributeId).toRight(NotFoundAttribute(attributeId.toString))
-        } yield maybeTenant.deleteAttribute(attributeId, dateTime)
-        result.fold(fail(_)(replyTo), t => persistAndReply(t, TenantUpdated)(replyTo))
-
       case AddSelfcareIdTenantMapping(selfcareId, tenantId, replyTo) =>
         Effect.persist(SelfcareMappingCreated(selfcareId, tenantId)).thenReply(replyTo)(_ => success(()))
 

--- a/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/commands.scala
+++ b/src/main/scala/it/pagopa/interop/tenantmanagement/model/persistence/commands.scala
@@ -35,13 +35,6 @@ final case class UpdateAttribute(
   replyTo: ActorRef[StatusReply[PersistentTenant]]
 ) extends Command
 
-final case class DeleteAttribute(
-  tenantId: String,
-  attributeId: UUID,
-  dateTime: OffsetDateTime,
-  replyTo: ActorRef[StatusReply[PersistentTenant]]
-) extends Command
-
 final case class GetTenantBySelfcareId(selfcareId: String, replyTo: ActorRef[StatusReply[UUID]]) extends Command
 
 final case class AddSelfcareIdTenantMapping(selfcareId: String, tenantId: UUID, replyTo: ActorRef[StatusReply[Unit]])

--- a/src/test/scala/it/pagopa/interop/tenantmanagement/authz/TenantApiServiceAuthzSpec.scala
+++ b/src/test/scala/it/pagopa/interop/tenantmanagement/authz/TenantApiServiceAuthzSpec.scala
@@ -75,13 +75,6 @@ class TenantApiServiceAuthzSpec extends ClusteredMUnitRouteTest {
     )
   }
 
-  test("Attributes api operation authorization spec should accept authorized roles for deleteTenantAttribute") {
-    validateAuthorization(
-      "deleteTenantAttribute",
-      { implicit c: Seq[(String, String)] => attributesService.deleteTenantAttribute("tenantId", "fakeAttributeId") }
-    )
-  }
-
   test("Attributes api operation authorization spec should accept authorized roles for updateTenantAttribute") {
     validateAuthorization(
       "updateTenantAttribute",

--- a/src/test/scala/it/pagopa/interop/tenantmanagement/provider/TenantSpec.scala
+++ b/src/test/scala/it/pagopa/interop/tenantmanagement/provider/TenantSpec.scala
@@ -218,46 +218,6 @@ class TenantSpec extends BaseIntegrationSpec {
     }
   }
 
-  test("Deleting an attribute must fail if tenant does not exist") {
-    val (system, _, _)                = suiteState()
-    implicit val s: ActorSystem[_]    = system
-    implicit val ec: ExecutionContext = system.executionContext
-
-    deleteTenantAttribute[Problem](UUID.randomUUID.toString, UUID.randomUUID.toString).map { result =>
-      assertEquals(result.status, 404)
-      assertEquals(result.errors.map(_.code), Seq("018-0004"))
-    }
-  }
-
-  test("Deleting an attribute must fail if attribute in the tenant doesn't exists") {
-    val (system, mockedTime, mockedUUID) = suiteState()
-    implicit val s: ActorSystem[_]       = system
-    implicit val ec: ExecutionContext    = system.executionContext
-
-    val (tenant, tenantSeed) = randomTenantAndSeed(mockedTime, mockedUUID)
-
-    createTenant(tenantSeed) >> deleteTenantAttribute[Problem](tenant.id.toString, UUID.randomUUID.toString).map {
-      result =>
-        assertEquals(result.status, 404)
-        assertEquals(result.errors.map(_.code), Seq("018-0007"))
-    }
-  }
-
-  test("Deleting an attribute must succeed if attribute exists in tenant") {
-    val (system, mockedTime, mockedUUID) = suiteState()
-    implicit val s: ActorSystem[_]       = system
-    implicit val ec: ExecutionContext    = system.executionContext
-
-    val (tenant, tenantSeed) = randomTenantAndSeed(mockedTime, mockedUUID)
-    val expected             = tenant.copy(attributes = Nil, updatedAt = mockedTime.some)
-
-    createTenant(tenantSeed) >> deleteTenantAttribute[Tenant](
-      tenant.id.toString,
-      tenant.attributes.head.certified.get.id.toString
-    )
-      .map { result => assertEquals(result, expected) }
-  }
-
   test("Updating an attribute must fail if tenant does not exist") {
     val (system, mockedTime, mockedUUID) = suiteState()
     implicit val s: ActorSystem[_]       = system

--- a/src/test/scala/it/pagopa/interop/tenantmanagement/utils/SpecHelper.scala
+++ b/src/test/scala/it/pagopa/interop/tenantmanagement/utils/SpecHelper.scala
@@ -120,11 +120,6 @@ trait SpecHelper {
     } yield result
   }
 
-  def deleteTenantAttribute[T](tenantId: String, attributeId: String)(implicit
-    actorSystem: ActorSystem[_],
-    um: Unmarshaller[HttpResponse, T]
-  ): Future[T] = performCall[T](HttpMethods.DELETE, s"tenants/${tenantId}/attributes/${attributeId}", None)
-
   private def performCall[T](verb: HttpMethod, path: String, data: Option[Source[ByteString, Any]])(implicit
     actorSystem: ActorSystem[_],
     um: Unmarshaller[HttpResponse, T]


### PR DESCRIPTION
This api is used nowhere and the whole revocation process is managed via updates by the process. It's better to completely remove this feature.
